### PR TITLE
Feat: 드래그 웹검색 시 image, snippet 추가

### DIFF
--- a/paperinsight/src/pages/pdfpreview.js
+++ b/paperinsight/src/pages/pdfpreview.js
@@ -65,7 +65,7 @@ const PDFPreview = ({ pdfUrl }) => {
 
   const handleWebSearch = async () => {
     setSearchResult(''); // Reset search result before making a new request
-
+  
     try {
       const response = await fetch(`http://${jhIp}:3000/search/searchWeb`, {
         method: 'POST',
@@ -74,19 +74,29 @@ const PDFPreview = ({ pdfUrl }) => {
         },
         body: JSON.stringify({ text: selectedText }),
       });
-
+  
       if (response.ok) {
         const data = await response.json();
         const formattedResult = data.result.map(result => 
-          `<li><a href="${result.link}" class="search-link" target="_blank">${result.title}</a></li>`
+          `<li class="search-item">
+            <a href="${result.link}" class="search-link" target="_blank">
+              <div class="search-item-header">
+                ${result.image ? `<img src="${result.image}" alt="${result.title}" class="search-image">` : ''}
+                <div class="search-item-content">
+                  ${result.title}
+                </div>
+              </div>
+              ${result.snippet ? `<p class="search-snippet">${result.snippet}</p>` : ''}
+            </a>
+          </li>`
         ).join('');
         const resultHtml = `
-          <div style="font-size: larger; font-weight: bold;">${selectedText}</div>
+          <div style="font-size: 20px; font-weight: bold;">Search results for ${selectedText}</div>
           <ul>${formattedResult}</ul>
         `;
         setSearchResult(resultHtml);
         setSearchAnchorEl(anchorEl); // Set search popover anchor after receiving the response
-
+  
       } else {
         console.error('Error fetching data:', response.statusText);
       }
@@ -94,6 +104,9 @@ const PDFPreview = ({ pdfUrl }) => {
       console.error('Error fetching data:', error);
     }
   };
+  
+  
+  
 
   const open = Boolean(anchorEl);
   const searchOpen = Boolean(searchAnchorEl);
@@ -106,6 +119,53 @@ const PDFPreview = ({ pdfUrl }) => {
         handleTextSelection(e);
       }
     }}>
+      <style>
+        {`
+        .search-link {
+            text-decoration: none;
+            color: inherit;
+            font-weight: bold;
+        }
+        .search-link:hover {
+            text-decoration: underline;
+            cursor: pointer;
+        }
+        .search-link .search-image,
+        .search-link .search-snippet,
+        .search-link .search-item-content {
+            display: inline-block;
+            vertical-align: middle;
+        }
+        .search-snippet {
+            font-size: 1em;
+            font-weight: normal;
+            color: #4d5156;
+            margin-top: 5px;
+        }
+        .search-image {
+            max-width: 60px;
+            max-height: 60px;
+            width: auto;
+            height: auto;
+            margin-right: 10px;
+        }
+        .search-item {
+            display: flex;
+            flex-direction: column; /* 세로 방향으로 정렬 */
+            margin-bottom: 20px;
+        }
+        .search-item-header {
+            display: flex;
+            align-items: flex-start;
+        }
+        .search-item-content {
+            display: flex;
+            flex-direction: column;
+            flex: 1;
+        }
+        `}
+      </style>
+
       {pdfUrl ? (
         <Worker workerUrl="https://unpkg.com/pdfjs-dist@3.0.279/build/pdf.worker.min.js">
           <Viewer


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 🌳 이슈 번호

---
<!-- 해당 pr과 연결된 이슈를 닫아주세요. close #이슈넘버 -->
close #8 


<br/>


### ☀️ 어떻게 이슈를 해결했나요?

---

- 드래그 검색 시 타이틀, 이미지, 스니펫 띄워지도록 구현
- API에서 받아온 response 값을 적절한 위치에 배치




<br/>


### ❄️ 주의할 점

---

- 전체적인 UI는 수정이 필요함

<!-- 수정/추가한 내용중 주의깊게 봐야하는 부분이 있다면, 스크린샷으로 해당 부분을 자세히 설명해주세요. 그리고 왜 그렇게 변경했는지도 써주세요  -->
