### PR TITLE
Fix: 챗봇 예시 질문 생성, 로그인 전 드라이브 저장 제한 구현

### DIFF
--- a/paperinsight/src/App.js
+++ b/paperinsight/src/App.js
@@ -49,6 +49,7 @@ const AppContent = () => {
   const [keywordLoading, setKeywordLoading] = useState(false);
   const [wikiLoading, setWikiLoading] = useState(false);
   const [language, setLanguage] = useState('');
+  const [thumbnailFileName, setThumbnailFileName] = useState('');
   const { accessToken } = useContext(AuthContext);
 
 
@@ -218,7 +219,7 @@ const handleFileUploadComplete = async (fileUrl, uuid, region) => {
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
-      <Header fileName={driveFileName || searchFileName} />
+      <Header fileName={thumbnailFileName}/>
       <Box sx={{ display: 'flex', flexGrow: 1, overflow: 'hidden', marginTop: `${appBarHeight}px` }}>
         <Drawer
           variant="permanent"
@@ -260,15 +261,18 @@ const handleFileUploadComplete = async (fileUrl, uuid, region) => {
                   }}>
                   {isDriveVisible ? (
                     <Routes>
-                      <Route path="/drive" element={<Drive
+                      <Route path="/drive" element={
+                        <Drive
                         setSelectedPdf={setDriveSelectedPdf} // pdfurl을 drive에서 받아옴 
                         setFileName={setDriveFileName}
                         setIsDriveVisible={setIsDriveVisible}
                         handleButtonClick={handleDrivePdfSelection}
                         handlePdfSelection={handleDrivePdfSelection}
                         onFileUpload={handleFileUploadComplete}
+                        setThumbnailFileName={setThumbnailFileName} 
                       />} />
-                      <Route path="/search" element={<Search
+                      <Route path="/search" element={
+                        <Search
                         setSelectedPdf={setSearchSelectedPdf}
                         setFileName={setSearchFileName}
                         handleButtonClick={handleSearchPdfSelection}
@@ -320,7 +324,7 @@ const handleFileUploadComplete = async (fileUrl, uuid, region) => {
                           fullText={fullText}
                           ocrCompleted={ocrCompleted}
                           uploadedFileUrl={pdfUrl}
-                          // pdfState={location.pathname === "/drive" ? drivePdfState : searchPdfState}
+                          pdfState={location.pathname === "/drive" ? drivePdfState : searchPdfState}
                           language={language}
                         />
                       ) : driveSelectedPdf || searchSelectedPdf ? (

--- a/paperinsight/src/pages/drive.js
+++ b/paperinsight/src/pages/drive.js
@@ -15,7 +15,7 @@ import CloseIcon from '@mui/icons-material/Close';
 pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.min.js`;
 const MAIN_FASTAPI = process.env.REACT_APP_MainFastAPI;
 
-function Drive({ setSelectedPdf, setFileName, setIsDriveVisible, handlePdfSelection, onFileUpload }) {
+function Drive({ setSelectedPdf, setFileName, setIsDriveVisible, handlePdfSelection, onFileUpload, setThumbnailFileName}) {
 
   const { email, accessToken, refreshToken } = useContext(AuthContext);
 
@@ -26,6 +26,8 @@ function Drive({ setSelectedPdf, setFileName, setIsDriveVisible, handlePdfSelect
   const [thumbnails, setThumbnails] = useState([]);
   const navigate = useNavigate();
   const [selectedThumbnail, setSelectedThumbnail] = useState(null);
+
+  
 
 
   // console.log(`drive로 이동했을때의 api :  ${api}`);
@@ -103,6 +105,16 @@ function Drive({ setSelectedPdf, setFileName, setIsDriveVisible, handlePdfSelect
     }
   };
 
+  
+  const handleThumbnailClick = (fileUrl, name, thumbnailKey) => {
+    console.log("Home component - Thumbnail clicked. fileUrl:", fileUrl, "thumbnailName:", name, "thumbnailKey:", thumbnailKey);
+    setSelectedPdf(fileUrl);
+    setFileName(name);
+    setThumbnailFileName(name);
+    handlePdfSelection(fileUrl, thumbnailKey, name); // thumbnailName 대신 thumbnailKey를 전달
+  };
+
+
   const handleClickOpen = () => {
     setOpen(true);
     navigate('/drive');
@@ -120,6 +132,14 @@ function Drive({ setSelectedPdf, setFileName, setIsDriveVisible, handlePdfSelect
   };
 
   const handleFileUpload = async () => {
+    if (!accessToken) {
+      const goToLogin = window.confirm("이 기능을 사용하려면 로그인이 필요합니다. 로그인 페이지로 이동하시겠습니까?");
+      if (goToLogin){
+        navigate('/login');
+      }
+      return;
+    }
+
     if (!file) return;
 
     const formData = new FormData();
@@ -127,15 +147,6 @@ function Drive({ setSelectedPdf, setFileName, setIsDriveVisible, handlePdfSelect
 
     try {
       console.log(`Bearer ${accessToken}`);
-
-      // const response = await axios.post(`${process.env.REACT_APP_API_BASE_URL}/api/auth/uploadS3`, formData, {
-      //   headers: {
-      //     'authorization': `Bearer ${accessToken}`
-      //   }
-      // });
-
-      // const data = response.data.data;
-
 
       // Generate presigned URL
       const presignedResponse = await axios.post(`${process.env.REACT_APP_API_BASE_URL}/api/auth/generateS3`, {
@@ -210,13 +221,6 @@ function Drive({ setSelectedPdf, setFileName, setIsDriveVisible, handlePdfSelect
       alert('파일 삭제 중 오류가 발생했습니다.');
       console.error('Error deleting file:', error);
     }
-  };
-
-  const handleThumbnailClick = (fileUrl, name, thumbnailKey) => {
-    console.log("Home component - Thumbnail clicked. fileUrl:", fileUrl, "thumbnailName:", name, "thumbnailKey:", thumbnailKey);
-    setSelectedPdf(fileUrl);
-    setFileName(name);
-    handlePdfSelection(fileUrl, thumbnailKey, name); // thumbnailName 대신 thumbnailKey를 전달
   };
 
 


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 🌳 이슈 번호

---

챗봇 예시 질문 생성, 로그인 전 드라이브 저장 제한 구현
close #77 


<br/>


### ☀️ 어떻게 이슈를 해결했나요?

---

- 챗봇 예시 질문 클릭하면 챗봇에 전송
- 로그인 전에 파일 업로드 시  드라이브 저장 제한하도록 수정

<br/>


### ❄️ 주의할 점

---

<!-- 수정/추가한 내용중 주의깊게 봐야하는 부분이 있다면, 스크린샷으로 해당 부분을 자세히 설명해주세요. 그리고 왜 그렇게 변경했는지도 써주세요  -->
